### PR TITLE
feat: handle Firefox data dir under .config/mozilla and fallback to .mozilla/config

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -164,9 +164,9 @@ class Plugin(PluginInstance, IndexQueryHandler):
                 self.firefox_icon_factory = lambda: Icon.fileType("/Applications/Firefox.app")
             case "Linux":
                 # Try XDG-compliant location first, fallback to legacy path
-                new_path = Path.home() / ".config" / "mozilla" / "firefox"
+                xdg_path = Path.home() / ".config" / "mozilla" / "firefox"
                 legacy_path = Path.home() / ".mozilla" / "firefox"
-                self.firefox_data_dir = new_path if (new_path / "profiles.ini").exists() else legacy_path
+                self.firefox_data_dir = xdg_path if xdg_path.exists() else legacy_path
                 self.firefox_icon_factory = lambda: Icon.theme("firefox")
             case _:
                 raise NotImplementedError(f"Unsupported platform: {platform.system()}")

--- a/__init__.py
+++ b/__init__.py
@@ -163,7 +163,10 @@ class Plugin(PluginInstance, IndexQueryHandler):
                 self.firefox_data_dir = Path.home() / "Library" / "Application Support" / "Firefox"
                 self.firefox_icon_factory = lambda: Icon.fileType("/Applications/Firefox.app")
             case "Linux":
-                self.firefox_data_dir = Path.home() / ".mozilla" / "firefox"
+                # Try XDG-compliant location first, fallback to legacy path
+                new_path = Path.home() / ".config" / "mozilla" / "firefox"
+                legacy_path = Path.home() / ".mozilla" / "firefox"
+                self.firefox_data_dir = new_path if (new_path / "profiles.ini").exists() else legacy_path
                 self.firefox_icon_factory = lambda: Icon.theme("firefox")
             case _:
                 raise NotImplementedError(f"Unsupported platform: {platform.system()}")


### PR DESCRIPTION
On my system, Firefox profiles are under `$home/.config/mozilla`, but the plugin only reads from `$home/.mozilla`.

Change: check under `.config`, then fallback to the previous path

✅ working fine here